### PR TITLE
Avoid NPE if tid is null.

### DIFF
--- a/src/main/java/hudson/plugins/twitter/messages/DefaultTweetBuilder.java
+++ b/src/main/java/hudson/plugins/twitter/messages/DefaultTweetBuilder.java
@@ -68,7 +68,7 @@ public class DefaultTweetBuilder implements TweetBuilder {
   
   private void addUserToBuilder(User user, StringBuilder userString) {
     UserTwitterProperty tid = user.getProperty(UserTwitterProperty.class);
-    if (tid.getTwitterid() != null) {
+    if (tid != null && tid.getTwitterid() != null) {
       userString.append("@").append(tid.getTwitterid()).append(" ");
     }    
   }


### PR DESCRIPTION
Using the latest Jenkins user.getProperty returns null if the property does not exist. This causes a NPE.
